### PR TITLE
fix(json_parser): fixing the "TypeError('the JSON object must be str,…

### DIFF
--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -67,7 +67,8 @@ def fix_json(json_str: str, schema: str, debug=False) -> str:
         print(f"Fixed JSON: {result_string}")
         print("----------- END OF FIX ATTEMPT ----------------")
     try:
-        return json.loads(result_string)
+        json.loads(result_string) # just check the validity
+        return result_string
     except:
         # Get the call stack:
         # import traceback


### PR DESCRIPTION
… bytes or bytearray, not dict')" after a json_fix is successful