### PR TITLE
fix(json-jixer): enclose arguments in a python multi-line string so t…

### DIFF
--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -51,7 +51,7 @@ def fix_and_parse_json(json_str: str, try_to_fix_with_gpt: bool = True):
 def fix_json(json_str: str, schema: str, debug=False) -> str:
     # Try to fix the JSON using gpt:
     function_string = "def fix_json(json_str: str, schema:str=None) -> str:"
-    args = [json_str, schema]
+    args = [f"'''{json_str}'''", f"'''{schema}'''"]
     description_string = """Fixes the provided JSON string to make it parseable and fully complient with the provided schema.\n If an object or field specifed in the schema isn't contained within the correct JSON, it is ommited.\n This function is brilliant at guessing when the format is incorrect."""
 
     # If it doesn't already start with a "`", add one:


### PR DESCRIPTION
…he fix_json assistant (GPT-3.5) can understand we are providing 2 strings arguments instead of one